### PR TITLE
fix: improve serial port name handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ venv/
 .coverage
 coverage.xml
 htmlcov/
+build/
 
 src/*.egg-info/
 .coverage

--- a/src/embedded_cereal_bowl/monitor/monitor.py
+++ b/src/embedded_cereal_bowl/monitor/monitor.py
@@ -93,6 +93,20 @@ def get_serial_prefix() -> str:
     return "/dev/tty"
 
 
+def get_serial_port_name(port_arg: str) -> str:
+    """Construct the full serial port name based on user input and OS."""
+    if os.name == "nt":
+        return port_arg
+
+    if port_arg.startswith("/"):
+        return port_arg
+
+    if port_arg.startswith("tty"):
+        return f"/dev/{port_arg}"
+
+    return f"{get_serial_prefix()}{port_arg}"
+
+
 def clear_terminal() -> None:
     # clear screen
     if os.name == "nt":
@@ -317,7 +331,8 @@ def main() -> None:
         clear_terminal()
 
     print(colour_str(f"{args}").dim())
-    serial_port_name = f"{get_serial_prefix()}{args.port}"
+
+    serial_port_name = get_serial_port_name(args.port)
 
     highlight_words = []
     if args.highlight:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -15,6 +15,7 @@ from src.embedded_cereal_bowl.monitor.monitor import (
     add_time_to_line,
     clear_terminal,
     create_replacement_lambda,
+    get_serial_port_name,
     get_serial_prefix,
     parse_arguments,
     run_serial_printing_with_logs,
@@ -99,6 +100,35 @@ class TestGetSerialPrefix:
         with patch("os.name", "posix"):
             prefix = get_serial_prefix()
             assert prefix == "/dev/tty"
+
+
+class TestGetSerialPortName:
+    """Test cases for get_serial_port_name function."""
+
+    def test_get_serial_port_name_nt(self):
+        """Test port name construction on Windows."""
+        with patch("os.name", "nt"):
+            assert get_serial_port_name("COM3") == "COM3"
+            assert get_serial_port_name("COM10") == "COM10"
+
+    def test_get_serial_port_name_unix_short(self):
+        """Test port name construction on Unix with short name."""
+        with patch("os.name", "posix"):
+            assert get_serial_port_name("ACM0") == "/dev/ttyACM0"
+            assert get_serial_port_name("USB0") == "/dev/ttyUSB0"
+
+    def test_get_serial_port_name_unix_tty(self):
+        """Test port name construction on Unix with tty prefix."""
+        with patch("os.name", "posix"):
+            assert get_serial_port_name("ttyACM0") == "/dev/ttyACM0"
+            assert get_serial_port_name("ttyUSB0") == "/dev/ttyUSB0"
+
+    def test_get_serial_port_name_unix_full(self):
+        """Test port name construction on Unix with full path."""
+        with patch("os.name", "posix"):
+            assert get_serial_port_name("/dev/ttyACM0") == "/dev/ttyACM0"
+            assert get_serial_port_name("/dev/rfcomm0") == "/dev/rfcomm0"
+            assert get_serial_port_name("/dev/pts/1") == "/dev/pts/1"
 
 
 class TestClearTerminal:


### PR DESCRIPTION
## Summary
- Improved serial port name resolution to support full paths (e.g., `/dev/ttyACM0`), `tty` prefixes (e.g., `ttyACM0`), and short names (e.g., `ACM0`).
- Added `build/` directory to `.gitignore`.
- Added unit tests for the new port name construction logic.
- Ensured code formatting and linting compliance using Ruff.