### PR TITLE
Add auto-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Build package
+        run: uv build
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: dist/*
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow that automatically creates a GitHub Release when a new version tag (matching `v*`) is pushed.

## Changes
- Created `.github/workflows/release.yml`
- Configured the workflow to:
  - Trigger on `push` of tags like `v1.0.0`
  - Build the package using `uv build`
  - Use `softprops/action-gh-release@v2` to create the release and upload build artifacts
  - Automatically generate release notes