### PR TITLE
Switch CI workflows to ubuntu-slim runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
   test:
     needs: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       matrix:
         python-version: ["3.12", "3.13", "3.14"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,6 @@ ignore = [
     "SIM108",  # Use ternary operator (keep readable)
     "B006",  # Mutable default argument (acceptable here)
     "SIM117",  # Combine with statements (keep readable)
-    "RUF059",  # Unpacked variable not used (test convenience)
     "E402",  # Module level import (test setup)
     "F841",  # Local variable assigned but never used (test convenience)
     "E712",  # Avoid equality comparisons to True (keep explicit)


### PR DESCRIPTION
Switches all GitHub Actions workflows from ubuntu-latest to ubuntu-slim runners for faster provisioning and smaller storage footprint.

Changes:
- ci.yml: Use ubuntu-slim for lint and test jobs
- release.yml: Use ubuntu-slim for release job
- pyproject.toml: Remove unrecognized RUF059 rule selector