### PR TITLE
Add --ignore-ext option to format-code and check-crlf

### DIFF
--- a/src/embedded_cereal_bowl/check_crlf.py
+++ b/src/embedded_cereal_bowl/check_crlf.py
@@ -67,7 +67,10 @@ def resolve_ignore_dirs(root: Path, ignore_patterns: list[str]) -> set[Path]:
 
 
 def check_crlf_in_root(
-    repo_path: Path, ignore_patterns: list[str], verbose: bool = False
+    repo_path: Path,
+    ignore_patterns: list[str],
+    verbose: bool = False,
+    ignore_extensions: list[str] = [],
 ) -> None:
     if not repo_path.is_dir():
         print(f"Error: Directory not found at '{repo_path}'")
@@ -83,10 +86,18 @@ def check_crlf_in_root(
         for d in sorted(ignored_dirs):
             print(f"   🚫 {d}")
 
+    ignored_exts = {ext.lstrip(".").lower() for ext in ignore_extensions}
+    if verbose and ignored_exts:
+        print(" Ignored Extensions ".center(MAX_WIDTH, "-"))
+        for ext in sorted(ignored_exts):
+            print(f"   🚫 *.{ext}")
+
     crlf_files_found = []
 
     # Use the custom scanner
     for file_path in scan_directory(repo_path, ignored_dirs):
+        if file_path.suffix.lstrip(".").lower() in ignored_exts:
+            continue
         if has_crlf_endings(file_path):
             # Calculate relative path for cleaner output using pathlib
             crlf_files_found.append(file_path.relative_to(repo_path))
@@ -128,6 +139,17 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--ignore-ext",
+        "-e",
+        nargs="+",
+        metavar="EXT",
+        default=[],
+        help=(
+            "One or more file extensions to ignore.\n"
+            "(e.g., --ignore-ext log .log txt)"
+        ),
+    )
+    parser.add_argument(
         "-v", "--verbose", action="store_true", help="Enable verbose output."
     )
     args = parser.parse_args()
@@ -138,6 +160,7 @@ def main() -> None:
             repo_path=Path(args.root_dir).resolve(),
             ignore_patterns=args.ignore,
             verbose=args.verbose,
+            ignore_extensions=args.ignore_ext,
         )
     except KeyboardInterrupt:
         print("Operation cancelled by user.")

--- a/src/embedded_cereal_bowl/formatter/formatter.py
+++ b/src/embedded_cereal_bowl/formatter/formatter.py
@@ -70,7 +70,10 @@ def scan_directory(
 
 
 def find_all_files(
-    root_dir: Path, ignore_patterns: list[str], verbose: bool
+    root_dir: Path,
+    ignore_patterns: list[str],
+    verbose: bool,
+    ignore_extensions: list[str] = [],
 ) -> dict[Path, dict[str, Any]]:
     """Finds all files for all configured formatters, respecting ignore globs."""
 
@@ -90,6 +93,12 @@ def find_all_files(
         for d in sorted(absolute_ignore_dirs):
             print(f"  🚫 {d}")
 
+    ignored_exts = {ext.lstrip(".").lower() for ext in ignore_extensions}
+    if verbose and ignored_exts:
+        print(" Ignored Extensions ".center(MAX_WIDTH, "-"))
+        for ext in sorted(ignored_exts):
+            print(f"  🚫 *.{ext}")
+
     name_lookup = {
         name: config
         for config in FORMATTER_CONFIG.values()
@@ -102,6 +111,8 @@ def find_all_files(
     }
 
     for file_path in scan_directory(root_dir, absolute_ignore_dirs):
+        if file_path.suffix.lstrip(".").lower() in ignored_exts:
+            continue
         config = name_lookup.get(file_path.name)
         if not config:
             config = extension_lookup.get(file_path.suffix)
@@ -234,9 +245,12 @@ def run_project_tasks(
     jobs: int | None = None,
     check: bool = False,
     verbose: bool = False,
+    ignore_extensions: list[str] = [],
 ) -> None:
     print(f"🚀 Scanning for all source files in: {root_dir}")
-    files_to_process = find_all_files(root_dir, ignore_patterns, verbose)
+    files_to_process = find_all_files(
+        root_dir, ignore_patterns, verbose, ignore_extensions
+    )
     process_files_parallel(files_to_process, root_dir, jobs, verbose, check)
 
 
@@ -305,6 +319,18 @@ def main() -> None:
             "changes and the associated required changes"
         ),
     )
+
+    parser.add_argument(
+        "--ignore-ext",
+        "-e",
+        nargs="+",
+        metavar="EXT",
+        default=[],
+        help=(
+            "One or more file extensions to ignore.\n"
+            "(e.g., --ignore-ext log .log txt)"
+        ),
+    )
     args = parser.parse_args()
     # fmt: on
 
@@ -317,6 +343,7 @@ def main() -> None:
             jobs=args.jobs,
             check=args.check,
             verbose=args.verbose,
+            ignore_extensions=args.ignore_ext,
         )
     except KeyboardInterrupt:
         print("Operation cancelled by user.")
@@ -328,6 +355,7 @@ def format_files(
     ignore_patterns: list[str] | None = None,
     jobs: int | None = None,
     verbose: bool = False,
+    ignore_extensions: list[str] | None = None,
 ) -> None:
     """Format files in a directory (for programmatic use)."""
     if not check_for_tools():
@@ -338,6 +366,7 @@ def format_files(
         jobs=jobs,
         check=False,
         verbose=verbose,
+        ignore_extensions=ignore_extensions or [],
     )
 
 
@@ -346,6 +375,7 @@ def check_format(
     ignore_patterns: list[str] | None = None,
     jobs: int | None = None,
     verbose: bool = False,
+    ignore_extensions: list[str] | None = None,
 ) -> None:
     """Check file formatting in a directory (for programmatic use)."""
     if not check_for_tools():
@@ -356,6 +386,7 @@ def check_format(
         jobs=jobs,
         check=True,
         verbose=verbose,
+        ignore_extensions=ignore_extensions or [],
     )
 
 

--- a/tests/test_check_crlf.py
+++ b/tests/test_check_crlf.py
@@ -62,6 +62,22 @@ def test_main_with_args():
             assert kwargs["verbose"] is True
 
 
+def test_main_with_ignore_ext():
+    """Test main function with --ignore-ext argument."""
+    with patch(
+        "sys.argv", ["check_crlf", "/some/path", "--ignore-ext", "log", "txt", "-v"]
+    ):
+        with patch(
+            "src.embedded_cereal_bowl.check_crlf.check_crlf_in_root"
+        ) as mock_check:
+            main()
+            mock_check.assert_called_once()
+            _, kwargs = mock_check.call_args
+            assert kwargs["repo_path"] == Path("/some/path").resolve()
+            assert kwargs["ignore_extensions"] == ["log", "txt"]
+            assert kwargs["verbose"] is True
+
+
 def test_scan_directory_symlink(tmp_path):
     """Test scan_directory skips symlinks."""
     target = tmp_path / "target.txt"
@@ -166,6 +182,63 @@ def test_check_crlf_in_root_found(tmp_path, capsys):
     captured = capsys.readouterr()
     assert "Found files with CRLF line endings" in captured.out
     assert "dirty.txt" in captured.out
+
+
+def test_check_crlf_ignore_extensions(tmp_path, capsys):
+    f1 = tmp_path / "crlf.txt"
+    f1.write_bytes(b"unix\r\n")
+    f2 = tmp_path / "crlf.log"
+    f2.write_bytes(b"windows\r\n")
+
+    with pytest.raises(SystemExit) as excinfo:
+        check_crlf_in_root(tmp_path, [], ignore_extensions=["log"])
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "crlf.txt" in captured.out
+    assert "crlf.log" not in captured.out
+
+
+def test_check_crlf_ignore_extensions_with_dot(tmp_path, capsys):
+    f1 = tmp_path / "crlf.txt"
+    f1.write_bytes(b"unix\r\n")
+    f2 = tmp_path / "crlf.log"
+    f2.write_bytes(b"windows\r\n")
+
+    with pytest.raises(SystemExit) as excinfo:
+        check_crlf_in_root(tmp_path, [], ignore_extensions=[".log"])
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "crlf.txt" in captured.out
+    assert "crlf.log" not in captured.out
+
+
+def test_check_crlf_ignore_extensions_verbose(tmp_path, capsys):
+    f1 = tmp_path / "crlf.txt"
+    f1.write_bytes(b"unix\r\n")
+    f2 = tmp_path / "crlf.log"
+    f2.write_bytes(b"windows\r\n")
+
+    with pytest.raises(SystemExit) as excinfo:
+        check_crlf_in_root(tmp_path, [], verbose=True, ignore_extensions=["log", "tmp"])
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "Ignored Extensions" in captured.out
+    assert "log" in captured.out
+    assert "tmp" in captured.out
+
+
+def test_check_crlf_ignore_extensions_case_insensitive(tmp_path, capsys):
+    f1 = tmp_path / "crlf.txt"
+    f1.write_bytes(b"unix\r\n")
+    f2 = tmp_path / "crlf.LOG"
+    f2.write_bytes(b"windows\r\n")
+
+    with pytest.raises(SystemExit) as excinfo:
+        check_crlf_in_root(tmp_path, [], ignore_extensions=["log"])
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "crlf.txt" in captured.out
+    assert "crlf.LOG" not in captured.out
 
 
 def test_main_keyboard_interrupt():

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -68,6 +68,44 @@ class TestFormatterDiscovery:
         with pytest.raises(SystemExit):
             find_all_files(Path("/nonexistent"), [], False)
 
+    def test_find_all_files_ignore_extensions(self, tmp_path, capsys):
+        (tmp_path / "test.cpp").write_text("code")
+        (tmp_path / "ignore.log").write_text("log content")
+        (tmp_path / "ignore.txt").write_text("text content")
+
+        result = find_all_files(tmp_path, [], verbose=False, ignore_extensions=["log"])
+        assert len(result) == 1
+        assert "test.cpp" in str(result.keys())
+
+    def test_find_all_files_ignore_extensions_with_dot(self, tmp_path, capsys):
+        (tmp_path / "test.cpp").write_text("code")
+        (tmp_path / "ignore.log").write_text("log content")
+
+        result = find_all_files(tmp_path, [], verbose=False, ignore_extensions=[".log"])
+        assert len(result) == 1
+        assert "test.cpp" in str(result.keys())
+
+    def test_find_all_files_ignore_extensions_verbose(self, tmp_path, capsys):
+        (tmp_path / "test.cpp").write_text("code")
+        (tmp_path / "ignore.log").write_text("log content")
+
+        result = find_all_files(
+            tmp_path, [], verbose=True, ignore_extensions=["log", "txt"]
+        )
+        assert len(result) == 1
+        captured = capsys.readouterr()
+        assert "Ignored Extensions" in captured.out
+        assert "log" in captured.out
+        assert "txt" in captured.out
+
+    def test_find_all_files_ignore_extensions_case_insensitive(self, tmp_path):
+        (tmp_path / "test.cpp").write_text("code")
+        (tmp_path / "ignore.LOG").write_text("log content")
+
+        result = find_all_files(tmp_path, [], verbose=False, ignore_extensions=["log"])
+        assert len(result) == 1
+        assert "test.cpp" in str(result.keys())
+
 
 class TestFileProcessing:
     """Test processing individual files and parallel execution."""
@@ -205,6 +243,22 @@ class TestFormatterCLI:
             patch("sys.argv", ["formatter", "src"]),
         ):
             main()
+
+    def test_main_with_ignore_ext(self):
+        with (
+            patch(
+                "src.embedded_cereal_bowl.formatter.formatter.check_for_tools",
+                return_value=True,
+            ),
+            patch(
+                "src.embedded_cereal_bowl.formatter.formatter.run_project_tasks"
+            ) as mock_run,
+            patch("sys.argv", ["formatter", "src", "--ignore-ext", "log", "txt"]),
+        ):
+            main()
+            mock_run.assert_called_once()
+            _, kwargs = mock_run.call_args
+            assert kwargs["ignore_extensions"] == ["log", "txt"]
 
     def test_main_no_tools(self):
         with (


### PR DESCRIPTION
## Summary
- Add `--ignore-ext` (shorthand `-e`) option to both `format-code` and `check-crlf` commands
- Allows ignoring specific file extensions from formatting/CRLF checking
- Extensions can be specified with or without leading dot (both `log` and `.log` work)
- Case-insensitive matching

## Usage Examples

```bash
# Ignore .log files when checking CRLF
check-crlf --ignore-ext log

# Ignore multiple extensions when formatting
format-code --ignore-ext log txt bin

# Short form
check-crlf -e log -v
format-code -e .log .tmp
```

## Changes
- `src/embedded_cereal_bowl/formatter/formatter.py`: Added `--ignore-ext` to CLI and `ignore_extensions` parameter to `find_all_files()`, `run_project_tasks()`, `format_files()`, and `check_format()`
- `src/embedded_cereal_bowl/check_crlf.py`: Added `--ignore-ext` to CLI and `ignore_extensions` parameter to `check_crlf_in_root()`
- `tests/test_formatter.py`: Added 5 new tests for ignore-ext functionality
- `tests/test_check_crlf.py`: Added 6 new tests for ignore-ext functionality