### PR TITLE
Add ty type checking to CI and project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,23 @@ jobs:
 
   type-check:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/astral-sh/ty:alpine
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          uv sync --all-extras --dev
+
       - name: Type check with ty
         run: |
-          ty check --output-format github
+          uv run ty check --output-format github
 
   test:
     needs: [lint, type-check]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,19 @@ jobs:
           ruff check src tests
           ruff format --check src tests
 
+  type-check:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/astral-sh/ty:alpine
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Type check with ty
+        run: |
+          ty check --output-format github
+
   test:
-    needs: lint
+    needs: [lint, type-check]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -91,7 +91,7 @@ pip install .
 | **pytest-mock** | >=3.10 | Test mocking | `pip install pytest-mock` |
 | **pytest-cov** | >=4.0 | Coverage | `pip install pytest-cov` |
 | **ruff** | >=0.1.0 | Linting/formatting | `pip install ruff` |
-| **mypy** | >=1.0 | Type checking | `pip install mypy` |
+| **ty** | >=0.0.27 | Type checking | `pip install ty` |
 | **bandit** | >=1.7 | Security scanning | `pip install bandit` |
 | **build** | >=0.8.0 | Package building | `pip install build` |
 
@@ -161,13 +161,13 @@ monitor --help
 ### Development Environment Test
 ```bash
 # Run test suite
-pytest --cov=src
+uv run pytest --cov=src
 
 # Run linting
-ruff check src
+uv run ruff check src tests
 
 # Run type checking
-mypy src
+uv run ty check
 
 # Run security check
 bandit -r src
@@ -303,7 +303,7 @@ pip install --upgrade pyserial regex colorama
 pip uninstall embedded-cereal-bowl
 
 # Remove development dependencies
-pip uninstall pytest ruff mypy bandit
+pip uninstall pytest ruff ty bandit
 ```
 
 ### Clean Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest-mock>=3.10",
     "pytest-sugar",
     "ruff>=0.1.0",
+    "ty>=0.0.27",
     "build>=0.8.0",
     "clang-format>=17.0.6",
     "cmakelang>=0.6.13",
@@ -108,6 +109,27 @@ ignore = [
 quote-style = "double"
 indent-style = "space"
 line-ending = "auto"
+
+[tool.ty.environment]
+python-version = "3.12"
+root = ["./src", "."]
+
+[tool.ty.rules]
+all = "error"
+
+[tool.ty.src]
+include = ["src", "tests"]
+exclude = [
+    "build",
+    "htmlcov",
+    "src/embedded_cereal_bowl.egg-info",
+]
+
+[[tool.ty.overrides]]
+include = ["tests/**", "**/test_*.py"]
+
+[tool.ty.overrides.rules]
+all = "warn"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/embedded_cereal_bowl/monitor/monitor.py
+++ b/src/embedded_cereal_bowl/monitor/monitor.py
@@ -8,7 +8,7 @@ import threading
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime
-from typing import Any
+from typing import Protocol, TextIO
 
 import regex as re
 import serial
@@ -17,6 +17,12 @@ from .. import __version__
 from ..utils.color_utils import colour_str
 
 ASNI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+
+
+class ReplacementMatch(Protocol):
+    def start(self) -> int: ...
+
+    def group(self) -> str: ...
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -158,8 +164,8 @@ def add_time_to_line(print_time: str | None) -> str:
 
 def create_replacement_lambda(
     current_line_state: str,
-) -> Callable[[re.Match[str]], str]:
-    def find_and_replace(match: re.Match[str]) -> str:
+) -> Callable[[ReplacementMatch], str]:
+    def find_and_replace(match: ReplacementMatch) -> str:
         # Part of the line before the current match
         pre_match_str = current_line_state[: match.start()]
         # Find all ANSI codes before the match
@@ -189,7 +195,7 @@ def create_replacement_lambda(
 
 
 def send_serial_data(
-    ser: serial.Serial, data: str, print_time: str | None, file: Any | None
+    ser: serial.Serial, data: str, print_time: str | None, file: TextIO | None
 ) -> bool:
     """Send data to serial port and log it if logging is enabled."""
     try:
@@ -215,8 +221,8 @@ def send_serial_data(
 
 def handle_user_input(
     ser: serial.Serial,
-    print_time: str,
-    file: Any | None,
+    print_time: str | None,
+    file: TextIO | None,
     stop_event: threading.Event,
 ) -> None:
     """Handle user keyboard input for sending serial data."""
@@ -241,7 +247,7 @@ def handle_user_input(
 def serial_loop(
     ser: serial.Serial,
     print_time: str | None,
-    file: Any | None,
+    file: TextIO | None,
     highlight_words: list[str] | None = None,
     enable_send: bool = False,
 ) -> None:
@@ -309,7 +315,7 @@ def run_serial_printing(
     serial_port_name: str,
     baud: int,
     print_time: str | None = None,
-    file: Any | None = None,
+    file: TextIO | None = None,
     highlight_words: list[str] | None = None,
     enable_send: bool = False,
 ) -> None:

--- a/src/embedded_cereal_bowl/utils/color_utils.py
+++ b/src/embedded_cereal_bowl/utils/color_utils.py
@@ -16,9 +16,9 @@ class colour_str:
         prefix = "".join(self.codes)
         return f"{prefix}{self.s}{Style.RESET_ALL}"
 
-    def _add_style(self, style_code: str) -> "colour_str":
+    def _add_style(self, style_code: object) -> "colour_str":
         """Adds a style code and returns self to allow chaining."""
-        self.codes.append(style_code)
+        self.codes.append(str(style_code))
         return self
 
     def red(self) -> "colour_str":

--- a/uv.lock
+++ b/uv.lock
@@ -165,6 +165,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-sugar" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -180,6 +181,7 @@ requires-dist = [
     { name = "pytest-sugar", marker = "extra == 'dev'" },
     { name = "regex", specifier = ">=2022.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.27" },
 ]
 provides-extras = ["dev"]
 
@@ -421,4 +423,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/de/e5cf1f151cf52fe1189e42d03d90909d7d1354fdc0c1847cbb63a0baa3da/ty-0.0.27.tar.gz", hash = "sha256:d7a8de3421d92420b40c94fe7e7d4816037560621903964dd035cf9bd0204a73", size = 5424130, upload-time = "2026-03-31T19:07:20.806Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/20/2a9ea661758bd67f2bfd54ce9daacb5a26c56c5f8b49fbd9a43b365a8a7d/ty-0.0.27-py3-none-linux_armv6l.whl", hash = "sha256:eb14456b8611c9e8287aa9b633f4d2a0d9f3082a31796969e0b50bdda8930281", size = 10571211, upload-time = "2026-03-31T19:07:23.28Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b2/8887a51f705d075ddbe78ae7f0d4755ef48d0a90235f67aee289e9cee950/ty-0.0.27-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:02e662184703db7586118df611cf24a000d35dae38d950053d1dd7b6736fd2c4", size = 10427576, upload-time = "2026-03-31T19:07:15.499Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c3/79d88163f508fb709ce19bc0b0a66c7c64b53d372d4caa56172c3d9b3ae8/ty-0.0.27-py3-none-macosx_11_0_arm64.whl", hash = "sha256:be5fc2899441f7f8f7ef40f9ffd006075a5ff6b06c44e8d2aa30e1b900c12f51", size = 9870359, upload-time = "2026-03-31T19:07:36.852Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4d/ed1b0db0e1e46b5ed4976bbfe0d1825faf003b4e3774ef28c785ed73e4bb/ty-0.0.27-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30231e652b14742a76b64755e54bf0cb1cd4c128bcaf625222e0ca92a2094887", size = 10380488, upload-time = "2026-03-31T19:07:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/20372f6d510b01570028433064880adec2f8abe68bf0c4603be61a560bef/ty-0.0.27-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5a119b1168f64261b3205a37e40b5b6c4aac8fd58e4587988f4e4b22c3c79847", size = 10390248, upload-time = "2026-03-31T19:07:28.345Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/46b31a7311306be1a560f7f20fdc37b5bf718787f60626cd265d9b637554/ty-0.0.27-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e38f4e187b6975d2cbebf0f1eb1221f8f64f6e509bad14d7bb2a91afc97e4956", size = 10878479, upload-time = "2026-03-31T19:07:39.393Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ba/5231a2a1fb1cebe053a25de8fded95e1a30a1e77d3628a9e58487297bafc/ty-0.0.27-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a07b1a8fbb23844f6d22091275430d9ac617175f34aa99159b268193de210389", size = 11461232, upload-time = "2026-03-31T19:07:02.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/37/558abab3e1f6670493524f61280b4dfcc3219555f13889223e733381dfab/ty-0.0.27-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d3ec4033031f240836bb0337274bac5c49dde312c7c6d7575451ed719bf8ffa3", size = 11133002, upload-time = "2026-03-31T19:07:18.371Z" },
+    { url = "https://files.pythonhosted.org/packages/32/38/188c14a57f52160407ce62c6abb556011718fd0bcbe1dca690529ce84c46/ty-0.0.27-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:924a8849afd500d260bf5b7296165a05b7424fbb6b19113f30f3b999d682873f", size = 10986624, upload-time = "2026-03-31T19:07:13.066Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f1/667a71393f47d2cd6ba9ed07541b8df3eb63aab1f2ee658e77d91b8362fa/ty-0.0.27-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d8270026c07e7423a1b3a3fd065b46ed1478748f0662518b523b57744f3fa025", size = 10366721, upload-time = "2026-03-31T19:07:00.131Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/aa/8edafe41be898bda774249abc5be6edd733e53fb1777d59ea9331e38537d/ty-0.0.27-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e26e9735d3bdfd95d881111ad1cf570eab8188d8c3be36d6bcaad044d38984d8", size = 10412239, upload-time = "2026-03-31T19:07:05.297Z" },
+    { url = "https://files.pythonhosted.org/packages/53/ff/8bafaed4a18d38264f46bdfc427de7ea2974cf9064e4e0bdb1b6e6c724e3/ty-0.0.27-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7c09cc9a699810609acc0090af8d0db68adaee6e60a7c3e05ab80cc954a83db7", size = 10573507, upload-time = "2026-03-31T19:06:57.064Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/63a8284a2fefd08ab56ecbad0fde7dd4b2d4045a31cf24c1d1fcd9643227/ty-0.0.27-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2d3e02853bb037221a456e034b1898aaa573e6374fbb53884e33cb7513ccb85a", size = 11090233, upload-time = "2026-03-31T19:07:34.139Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d3/d6fa1cafdfa2b34dbfa304fc6833af8e1669fc34e24d214fa76d2a2e5a25/ty-0.0.27-py3-none-win32.whl", hash = "sha256:34e7377f2047c14dbbb7bf5322e84114db7a5f2cb470db6bee63f8f3550cfc1e", size = 9984415, upload-time = "2026-03-31T19:07:07.98Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e6/dd4e27da9632b3472d5711ca49dbd3709dbd3e8c73f3af6db9c254235ca9/ty-0.0.27-py3-none-win_amd64.whl", hash = "sha256:3f7e4145aad8b815ed69b324c93b5b773eb864dda366ca16ab8693ff88ce6f36", size = 10961535, upload-time = "2026-03-31T19:07:10.566Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1a/824b3496d66852ed7d5d68d9787711131552b68dce8835ce9410db32e618/ty-0.0.27-py3-none-win_arm64.whl", hash = "sha256:95bf8d01eb96bb2ba3ffc39faff19da595176448e80871a7b362f4d2de58476c", size = 10376689, upload-time = "2026-03-31T19:07:25.732Z" },
 ]


### PR DESCRIPTION
Add Astral ty to the project as the type checker, configure it for src and tests, and enforce it in CI. The branch also includes the source typing cleanup and docs updates needed to make ty pass locally.

CI note: the current ty container job is failing because the container does not have the project dependencies installed, so ty cannot resolve imports such as regex, serial, colorama, and pytest. Local checks pass because uv sync installs the dev environment before ty runs.