### PR TITLE
Use git ls-files for formatter discovery

### DIFF
--- a/docs/code-formatter.md
+++ b/docs/code-formatter.md
@@ -44,7 +44,7 @@ cmake-format --version
 ## 🔧 Full Command Reference
 
 ```bash
-usage: formatter.py [-h] [-i DIR [DIR ...]] [-j JOBS] [-v] [--check] [root_dir]
+usage: formatter.py [-h] [-i DIR [DIR ...]] [-j JOBS] [-v] [--check] [--no-git-walk] [root_dir]
 ```
 
 ### Options Details
@@ -55,6 +55,7 @@ usage: formatter.py [-h] [-i DIR [DIR ...]] [-j JOBS] [-v] [--check] [root_dir]
 | Jobs | `-j` | `--jobs` | Parallel jobs | `--jobs 4` |
 | Verbose | `-v` | `--verbose` | Detailed output | `--verbose` |
 | Check Only | `--check` | `-c` | Check without changes | `--check` |
+| Manual Walk |  | `--no-git-walk` | Scan the filesystem instead of `git ls-files` | `--no-git-walk` |
 | Help | `-h` | `--help` | Show help | `-h` |
 
 ## 🎯 Usage Patterns
@@ -116,9 +117,11 @@ project/
 
 ### Smart File Discovery
 The formatter:
-- Scans recursively from root directory
+- Uses `git ls-files` by default, so only git-tracked files are considered
+- Falls back to a recursive filesystem scan when Git is unavailable or the root is not in a Git repository
+- Supports `--no-git-walk` to force the legacy recursive filesystem scan, including untracked files
 - Matches files by extension only
-- Respects ignore patterns
+- Respects `--ignore` patterns in both modes; in Git mode, tracked files under ignored directories are skipped after `git ls-files` returns them
 - Processes files in parallel
 
 ## 📊 Output Examples

--- a/docs/crlf-checker.md
+++ b/docs/crlf-checker.md
@@ -41,15 +41,22 @@ check-crlf --verbose
 ## 🔧 Command Reference
 
 ```bash
-usage: check_crlf.py [-h] [--ignore DIR [DIR ...]] [-v] [root_dir]
+usage: check_crlf.py [-h] [--ignore DIR [DIR ...]] [-v] [--no-git-walk] [root_dir]
 ```
 
 ### Options
 | Option | Short | Long | Description | Example |
-|---|---|---|---|
-| Ignore | `--ignore` | Skip directories | `--ignore build third-party` |
+|---|---|---|---|---|
+| Ignore | `-i` | `--ignore` | Skip directories | `--ignore build third-party` |
 | Verbose | `-v` | `--verbose` | Detailed output | `--verbose` |
+| Manual Walk |  | `--no-git-walk` | Scan the filesystem instead of `git ls-files` | `--no-git-walk` |
 | Help | `-h` | `--help` | Show help | `-h` |
+
+## File Discovery
+
+`check-crlf` uses `git ls-files` by default, so it checks git-tracked files only and ignores untracked files. If Git is unavailable or the root is not in a Git repository, it falls back to the legacy recursive filesystem walk. Use `--no-git-walk` to force that manual walk and include untracked files.
+
+`--ignore` applies in both modes. In Git mode, tracked files returned by `git ls-files` are skipped if they are under an ignored directory; in manual mode, ignored directories are pruned while walking.
 
 ## 📊 Output Examples
 

--- a/src/embedded_cereal_bowl/check_crlf.py
+++ b/src/embedded_cereal_bowl/check_crlf.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import shutil
+import subprocess  # nosec B404
 import sys
 from collections.abc import Iterator
 from pathlib import Path
@@ -66,15 +67,55 @@ def resolve_ignore_dirs(root: Path, ignore_patterns: list[str]) -> set[Path]:
     return resolved_ignores
 
 
+def is_excluded(file_path: Path, excluded_paths: set[Path]) -> bool:
+    """Return whether file_path is inside an excluded directory."""
+    try:
+        resolved = file_path.resolve()
+    except OSError:
+        return False
+    return any(
+        excluded == resolved or excluded in resolved.parents
+        for excluded in excluded_paths
+    )
+
+
+def git_ls_files(root_dir: Path, verbose: bool) -> list[Path] | None:
+    """Return git-tracked files rooted at root_dir, or None when git fails."""
+    try:
+        result = subprocess.run(  # nosec B603, B607
+            ["git", "-C", str(root_dir), "ls-files", "-z", "--"],
+            check=True,
+            capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        if verbose:
+            print(f"⚠️  git ls-files failed; falling back to manual walk: {exc}")
+        return None
+
+    paths = []
+    for raw_path in result.stdout.split(b"\0"):
+        if not raw_path:
+            continue
+        file_path = root_dir / raw_path.decode("utf-8", "surrogateescape")
+        if file_path.is_file() and not file_path.is_symlink():
+            paths.append(file_path)
+    return paths
+
+
 def check_crlf_in_root(
     repo_path: Path,
     ignore_patterns: list[str],
     verbose: bool = False,
-    ignore_extensions: list[str] = [],
+    ignore_extensions: list[str] | None = None,
+    use_git_walk: bool = True,
 ) -> None:
     if not repo_path.is_dir():
         print(f"Error: Directory not found at '{repo_path}'")
         sys.exit(1)
+
+    if isinstance(ignore_extensions, bool):
+        use_git_walk = ignore_extensions
+        ignore_extensions = None
 
     print(f"🔍 Checking for CRLF line endings in: {repo_path}")
 
@@ -86,7 +127,7 @@ def check_crlf_in_root(
         for d in sorted(ignored_dirs):
             print(f"   🚫 {d}")
 
-    ignored_exts = {ext.lstrip(".").lower() for ext in ignore_extensions}
+    ignored_exts = {ext.lstrip(".").lower() for ext in (ignore_extensions or [])}
     if verbose and ignored_exts:
         print(" Ignored Extensions ".center(MAX_WIDTH, "-"))
         for ext in sorted(ignored_exts):
@@ -94,8 +135,13 @@ def check_crlf_in_root(
 
     crlf_files_found = []
 
-    # Use the custom scanner
-    for file_path in scan_directory(repo_path, ignored_dirs):
+    discovered_files = git_ls_files(repo_path, verbose) if use_git_walk else None
+    if discovered_files is None:
+        discovered_files = list(scan_directory(repo_path, ignored_dirs))
+
+    for file_path in discovered_files:
+        if is_excluded(file_path, ignored_dirs):
+            continue
         if file_path.suffix.lstrip(".").lower() in ignored_exts:
             continue
         if has_crlf_endings(file_path):
@@ -152,6 +198,11 @@ def main() -> None:
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="Enable verbose output."
     )
+    parser.add_argument(
+        "--no-git-walk",
+        action="store_true",
+        help="Use the legacy manual filesystem walk instead of git ls-files.",
+    )
     args = parser.parse_args()
     # fmt: on
 
@@ -161,6 +212,7 @@ def main() -> None:
             ignore_patterns=args.ignore,
             verbose=args.verbose,
             ignore_extensions=args.ignore_ext,
+            use_git_walk=not args.no_git_walk,
         )
     except KeyboardInterrupt:
         print("Operation cancelled by user.")

--- a/src/embedded_cereal_bowl/formatter/formatter.py
+++ b/src/embedded_cereal_bowl/formatter/formatter.py
@@ -69,13 +69,56 @@ def scan_directory(
         print(f"⚠️  Permission denied: {root_path}", file=sys.stderr)
 
 
+def is_excluded(file_path: Path, excluded_paths: set[Path]) -> bool:
+    """Return whether file_path is inside an excluded directory."""
+    try:
+        resolved = file_path.resolve()
+    except OSError:
+        return False
+    return any(
+        excluded == resolved or excluded in resolved.parents
+        for excluded in excluded_paths
+    )
+
+
+def git_ls_files(root_dir: Path, verbose: bool) -> list[Path] | None:
+    """Return git-tracked files rooted at root_dir, or None when git fails."""
+    try:
+        result = subprocess.run(  # nosec B603, B607
+            ["git", "-C", str(root_dir), "ls-files", "-z", "--"],
+            check=True,
+            capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        if verbose:
+            print(
+                f"⚠️  git ls-files failed; falling back to manual walk: {exc}",
+                file=sys.stderr,
+            )
+        return None
+
+    paths = []
+    for raw_path in result.stdout.split(b"\0"):
+        if not raw_path:
+            continue
+        file_path = root_dir / raw_path.decode("utf-8", "surrogateescape")
+        if file_path.is_file() and not file_path.is_symlink():
+            paths.append(file_path)
+    return paths
+
+
 def find_all_files(
     root_dir: Path,
     ignore_patterns: list[str],
     verbose: bool,
-    ignore_extensions: list[str] = [],
+    ignore_extensions: list[str] | None = None,
+    use_git_walk: bool = True,
 ) -> dict[Path, dict[str, Any]]:
     """Finds all files for all configured formatters, respecting ignore globs."""
+
+    if isinstance(ignore_extensions, bool):
+        use_git_walk = ignore_extensions
+        ignore_extensions = None
 
     files_with_config: dict[Path, dict[str, Any]] = {}
 
@@ -93,7 +136,7 @@ def find_all_files(
         for d in sorted(absolute_ignore_dirs):
             print(f"  🚫 {d}")
 
-    ignored_exts = {ext.lstrip(".").lower() for ext in ignore_extensions}
+    ignored_exts = {ext.lstrip(".").lower() for ext in (ignore_extensions or [])}
     if verbose and ignored_exts:
         print(" Ignored Extensions ".center(MAX_WIDTH, "-"))
         for ext in sorted(ignored_exts):
@@ -110,7 +153,13 @@ def find_all_files(
         for ext in config.get("file_extensions", [])
     }
 
-    for file_path in scan_directory(root_dir, absolute_ignore_dirs):
+    discovered_files = git_ls_files(root_dir, verbose) if use_git_walk else None
+    if discovered_files is None:
+        discovered_files = list(scan_directory(root_dir, absolute_ignore_dirs))
+
+    for file_path in discovered_files:
+        if is_excluded(file_path, absolute_ignore_dirs):
+            continue
         if file_path.suffix.lstrip(".").lower() in ignored_exts:
             continue
         config = name_lookup.get(file_path.name)
@@ -245,11 +294,16 @@ def run_project_tasks(
     jobs: int | None = None,
     check: bool = False,
     verbose: bool = False,
-    ignore_extensions: list[str] = [],
+    ignore_extensions: list[str] | None = None,
+    use_git_walk: bool = True,
 ) -> None:
+    if isinstance(ignore_extensions, bool):
+        use_git_walk = ignore_extensions
+        ignore_extensions = None
+
     print(f"🚀 Scanning for all source files in: {root_dir}")
     files_to_process = find_all_files(
-        root_dir, ignore_patterns, verbose, ignore_extensions
+        root_dir, ignore_patterns, verbose, ignore_extensions, use_git_walk
     )
     process_files_parallel(files_to_process, root_dir, jobs, verbose, check)
 
@@ -331,6 +385,12 @@ def main() -> None:
             "(e.g., --ignore-ext log .log txt)"
         ),
     )
+
+    parser.add_argument(
+        "--no-git-walk",
+        action="store_true",
+        help="Use the legacy manual filesystem walk instead of git ls-files.",
+    )
     args = parser.parse_args()
     # fmt: on
 
@@ -344,6 +404,7 @@ def main() -> None:
             check=args.check,
             verbose=args.verbose,
             ignore_extensions=args.ignore_ext,
+            use_git_walk=not args.no_git_walk,
         )
     except KeyboardInterrupt:
         print("Operation cancelled by user.")
@@ -356,8 +417,13 @@ def format_files(
     jobs: int | None = None,
     verbose: bool = False,
     ignore_extensions: list[str] | None = None,
+    use_git_walk: bool = True,
 ) -> None:
     """Format files in a directory (for programmatic use)."""
+    if isinstance(ignore_extensions, bool):
+        use_git_walk = ignore_extensions
+        ignore_extensions = None
+
     if not check_for_tools():
         return
     run_project_tasks(
@@ -367,6 +433,7 @@ def format_files(
         check=False,
         verbose=verbose,
         ignore_extensions=ignore_extensions or [],
+        use_git_walk=use_git_walk,
     )
 
 
@@ -376,8 +443,13 @@ def check_format(
     jobs: int | None = None,
     verbose: bool = False,
     ignore_extensions: list[str] | None = None,
+    use_git_walk: bool = True,
 ) -> None:
     """Check file formatting in a directory (for programmatic use)."""
+    if isinstance(ignore_extensions, bool):
+        use_git_walk = ignore_extensions
+        ignore_extensions = None
+
     if not check_for_tools():
         return
     run_project_tasks(
@@ -387,6 +459,7 @@ def check_format(
         check=True,
         verbose=verbose,
         ignore_extensions=ignore_extensions or [],
+        use_git_walk=use_git_walk,
     )
 
 

--- a/tests/test_check_crlf.py
+++ b/tests/test_check_crlf.py
@@ -1,12 +1,14 @@
 """Tests for CRLF checker utility."""
 
+import subprocess
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
 from src.embedded_cereal_bowl.check_crlf import (
     check_crlf_in_root,
+    git_ls_files,
     has_crlf_endings,
     main,
     resolve_ignore_dirs,
@@ -60,6 +62,17 @@ def test_main_with_args():
             assert kwargs["repo_path"] == Path("/some/path").resolve()
             assert kwargs["ignore_patterns"] == ["build"]
             assert kwargs["verbose"] is True
+            assert kwargs["use_git_walk"] is True
+
+
+def test_main_no_git_walk():
+    """Test --no-git-walk passes manual discovery mode."""
+    with patch("sys.argv", ["check_crlf", "--no-git-walk", "/some/path"]):
+        with patch(
+            "src.embedded_cereal_bowl.check_crlf.check_crlf_in_root"
+        ) as mock_check:
+            main()
+            assert mock_check.call_args.kwargs["use_git_walk"] is False
 
 
 def test_main_with_ignore_ext():
@@ -170,6 +183,100 @@ def test_check_crlf_in_root_clean(tmp_path, capsys):
     assert excinfo.value.code == 0
     captured = capsys.readouterr()
     assert "No files with CRLF line endings were found" in captured.out
+
+
+def test_git_ls_files_success(tmp_path):
+    tracked = tmp_path / "tracked.txt"
+    tracked.write_text("content")
+    untracked = tmp_path / "untracked.txt"
+    untracked.write_text("content")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = Mock(stdout=b"tracked.txt\0")
+
+        assert git_ls_files(tmp_path, verbose=False) == [tracked]
+
+    mock_run.assert_called_once_with(
+        ["git", "-C", str(tmp_path), "ls-files", "-z", "--"],
+        check=True,
+        capture_output=True,
+    )
+
+
+def test_check_crlf_in_root_git_default_excludes_untracked(tmp_path, capsys):
+    tracked = tmp_path / "tracked.txt"
+    tracked.write_bytes(b"unix\n")
+    untracked = tmp_path / "untracked.txt"
+    untracked.write_bytes(b"windows\r\n")
+
+    with (
+        patch(
+            "src.embedded_cereal_bowl.check_crlf.git_ls_files", return_value=[tracked]
+        ),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        check_crlf_in_root(tmp_path, [])
+
+    assert excinfo.value.code == 0
+    assert "untracked.txt" not in capsys.readouterr().out
+
+
+def test_check_crlf_in_root_git_failure_fallback(tmp_path, capsys):
+    dirty = tmp_path / "dirty.txt"
+    dirty.write_bytes(b"windows\r\n")
+
+    with (
+        patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, [])),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        check_crlf_in_root(tmp_path, [], verbose=True)
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "falling back to manual walk" in captured.out
+    assert "dirty.txt" in captured.out
+
+
+def test_check_crlf_in_root_non_git_fallback(tmp_path):
+    clean = tmp_path / "clean.txt"
+    clean.write_bytes(b"unix\n")
+
+    with (
+        patch("subprocess.run", side_effect=subprocess.CalledProcessError(128, [])),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        check_crlf_in_root(tmp_path, [], verbose=False)
+
+    assert excinfo.value.code == 0
+
+
+def test_check_crlf_in_root_no_git_walk_manual_mode(tmp_path):
+    dirty = tmp_path / "dirty.txt"
+    dirty.write_bytes(b"windows\r\n")
+
+    with (
+        patch("src.embedded_cereal_bowl.check_crlf.git_ls_files") as mock_git,
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        check_crlf_in_root(tmp_path, [], use_git_walk=False)
+
+    mock_git.assert_not_called()
+    assert excinfo.value.code == 1
+
+
+def test_check_crlf_in_root_git_honors_ignore(tmp_path):
+    ignored = tmp_path / "ignored"
+    ignored.mkdir()
+    dirty = ignored / "dirty.txt"
+    dirty.write_bytes(b"windows\r\n")
+
+    with (
+        patch("src.embedded_cereal_bowl.check_crlf.git_ls_files", return_value=[dirty]),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        check_crlf_in_root(tmp_path, ["ignored"])
+
+    assert excinfo.value.code == 0
 
 
 def test_check_crlf_in_root_found(tmp_path, capsys):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -2,6 +2,7 @@
 
 import concurrent.futures
 import runpy
+import subprocess
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -12,6 +13,7 @@ from src.embedded_cereal_bowl.formatter.formatter import (
     check_format,
     find_all_files,
     format_files,
+    git_ls_files,
     main,
     process_files_parallel,
     process_one_file,
@@ -105,6 +107,85 @@ class TestFormatterDiscovery:
         result = find_all_files(tmp_path, [], verbose=False, ignore_extensions=["log"])
         assert len(result) == 1
         assert "test.cpp" in str(result.keys())
+
+    def test_git_ls_files_success(self, tmp_path):
+        tracked = tmp_path / "tracked.cpp"
+        tracked.write_text("code")
+        untracked = tmp_path / "untracked.cpp"
+        untracked.write_text("code")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(stdout=b"tracked.cpp\0")
+
+            assert git_ls_files(tmp_path, verbose=False) == [tracked]
+
+        mock_run.assert_called_once_with(
+            ["git", "-C", str(tmp_path), "ls-files", "-z", "--"],
+            check=True,
+            capture_output=True,
+        )
+
+    def test_find_all_files_git_default_excludes_untracked(self, tmp_path):
+        tracked = tmp_path / "tracked.cpp"
+        tracked.write_text("code")
+        untracked = tmp_path / "untracked.cpp"
+        untracked.write_text("code")
+
+        with patch(
+            "src.embedded_cereal_bowl.formatter.formatter.git_ls_files",
+            return_value=[tracked],
+        ):
+            result = find_all_files(tmp_path, [], verbose=False)
+
+        assert set(result) == {tracked}
+        assert untracked not in result
+
+    def test_find_all_files_git_failure_fallback(self, tmp_path, capsys):
+        tracked = tmp_path / "tracked.cpp"
+        tracked.write_text("code")
+
+        with patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, [])):
+            result = find_all_files(tmp_path, [], verbose=True)
+
+        assert set(result) == {tracked}
+        assert "falling back to manual walk" in capsys.readouterr().err
+
+    def test_find_all_files_non_git_fallback(self, tmp_path):
+        tracked = tmp_path / "tracked.cpp"
+        tracked.write_text("code")
+
+        with patch(
+            "subprocess.run", side_effect=subprocess.CalledProcessError(128, [])
+        ):
+            result = find_all_files(tmp_path, [], verbose=False)
+
+        assert set(result) == {tracked}
+
+    def test_find_all_files_no_git_walk_manual_mode(self, tmp_path):
+        tracked = tmp_path / "tracked.cpp"
+        tracked.write_text("code")
+
+        with patch(
+            "src.embedded_cereal_bowl.formatter.formatter.git_ls_files"
+        ) as mock_git:
+            result = find_all_files(tmp_path, [], verbose=False, use_git_walk=False)
+
+        mock_git.assert_not_called()
+        assert set(result) == {tracked}
+
+    def test_find_all_files_git_honors_ignore(self, tmp_path):
+        ignored = tmp_path / "ignored"
+        ignored.mkdir()
+        tracked = ignored / "tracked.cpp"
+        tracked.write_text("code")
+
+        with patch(
+            "src.embedded_cereal_bowl.formatter.formatter.git_ls_files",
+            return_value=[tracked],
+        ):
+            result = find_all_files(tmp_path, ["ignored"], verbose=False)
+
+        assert result == {}
 
 
 class TestFileProcessing:
@@ -260,6 +341,20 @@ class TestFormatterCLI:
             _, kwargs = mock_run.call_args
             assert kwargs["ignore_extensions"] == ["log", "txt"]
 
+    def test_main_no_git_walk(self):
+        with (
+            patch(
+                "src.embedded_cereal_bowl.formatter.formatter.check_for_tools",
+                return_value=True,
+            ),
+            patch(
+                "src.embedded_cereal_bowl.formatter.formatter.run_project_tasks"
+            ) as mock_run,
+            patch("sys.argv", ["formatter", "--no-git-walk", "src"]),
+        ):
+            main()
+        assert mock_run.call_args.kwargs["use_git_walk"] is False
+
     def test_main_no_tools(self):
         with (
             patch(
@@ -301,6 +396,7 @@ class TestFormatterCLI:
             format_files("src")
             check_format("src")
             assert mock_run.call_count == 2
+            assert mock_run.call_args.kwargs["use_git_walk"] is True
 
     def test_programmatic_no_tools(self):
         with patch(


### PR DESCRIPTION
## Summary
- default formatter and CRLF discovery to git ls-files
- add --no-git-walk to preserve legacy filesystem traversal
- update tests and docs for both discovery modes

## Validation
- uv run --extra dev sh -c 'pytest && ruff check . && ruff format --check .'